### PR TITLE
RandomResizedCrop replaces the deprecated method RandomSizedCrop

### DIFF
--- a/util/data_loader.py
+++ b/util/data_loader.py
@@ -37,7 +37,7 @@ transform_train = transforms.Compose([
 
 transform_train_largescale = transforms.Compose([
     transforms.Resize(256),
-    transforms.RandomSizedCrop(224),
+    transforms.RandomResizedCrop(224),
     transforms.RandomHorizontalFlip(),
     transforms.ToTensor(),
     transforms.Normalize(mean=[0.485, 0.456, 0.406],


### PR DESCRIPTION
Code doesn't run , gets error : `AttributeError: module 'torchvision.transforms' has no attribute 'RandomSizedCrop'`
based on Pytorch Doc: https://pytorch.org/vision/0.9/transforms.html 
Method `RandomSizedCrop` is deprecated and replaced by `RandomResizedCrop`